### PR TITLE
Landmark Data Format Fix for Unity

### DIFF
--- a/udp_connection/pose_processor.py
+++ b/udp_connection/pose_processor.py
@@ -13,12 +13,16 @@ class PoseProcessor:
             min_detection_confidence=0.5,
             min_tracking_confidence=0.5
         )
+        self.landmark_names = [lm.name for lm in mp.solutions.pose.PoseLandmark] 
 
     def extract_landmarks(self, frame_rgb):
         results = self.pose.process(frame_rgb)
         if results.pose_landmarks:
-            landmarks = [(lm.x, lm.y, lm.z) for lm in results.pose_landmarks.landmark]
-            return landmarks, results.pose_landmarks
+            landmarks_dict = {}
+            for i, landmark in enumerate(results.pose_landmarks.landmark):
+                landmark_name = self.landmark_names[i]
+                landmarks_dict[landmark_name] = [landmark.x, landmark.y, landmark.z]
+            return landmarks_dict, results.pose_landmarks 
         return None, None
 
     def close(self):

--- a/udp_connection/udp_signal_emitter.py
+++ b/udp_connection/udp_signal_emitter.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -7,9 +8,10 @@ class PoseSender:
     def __init__(self, socket_obj):
         self.socket = socket_obj
 
-    def send_landmarks(self, landmarks, addr_tuple):
+    def send_landmarks(self, landmarks_dict, addr_tuple):
         try:
-            serialized_landmarks = ";".join([f"{l[0]:.4f},{l[1]:.4f},{l[2]:.4f}" for l in landmarks])
-            self.socket.sendto(serialized_landmarks.encode('utf-8'), addr_tuple)
+            json_data = json.dumps(landmarks_dict)
+            serialized = json_data.encode('utf-8')
+            self.socket.sendto(serialized, addr_tuple)
         except Exception as e:
             logger.error(f"Error sending landmarks: {e}")


### PR DESCRIPTION
Adjusted PoseProcessor.py and PoseSender.py to send MediaPipe landmarks as JSON dictionaries {"NAME": [x,y,z]}. Ensures Unity's LandmarkManager parses data correctly.